### PR TITLE
Embed calendly snippet

### DIFF
--- a/_includes/component__contact.html
+++ b/_includes/component__contact.html
@@ -4,36 +4,19 @@
   <div class="wrap">
     <div class="contact__wrap">
       <header class="contact__header">
-        <h2 class="title">Get In Touch</h2>
-        <p class="subtitle--light">Prefer using email? Say hi at <a
+        <h2 class="title">Let's Talk</h2>
+        <p class="subtitle--light">Schedule 15 minutes to talk about how design and technology can help your business.</p>
+        <br>
+        <hr>
+        <p>Prefer using email? Say hi at <a
             href="mailto: {{ site.data.settings.contact_settings.email_address }}">{{ site.data.settings.contact_settings.email_address }}</a>
         </p>
       </header>
+      <!-- Calendly inline widget begin -->
+      <div class="calendly-inline-widget" data-url="https://calendly.com/design-help/15min?hide_event_type_details=1&hide_gdpr_banner=1&primary_color=067f8a" style="min-width:320px;height:630px;"></div>
+      <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js"></script>
+      <!-- Calendly inline widget end -->
 
-      <form method="POST" action="{{ site.data.settings.contact_settings.form_action }}" class="contact__form">
-        <div class="input-group">
-          <label for="name">Your Name</label>
-          <input type="text" name="name" id="name" placeholder="What should I call you?" />
-        </div>
-
-        <div class="input-group">
-          <label for="email">Your Email</label>
-          <input type="email" name="email" id="email" placeholder="What's your email address?" />
-        </div>
-
-        <div class="input-group">
-          <label for="message">Your Message</label>
-          <textarea name="message" id="message" placeholder="What’s on your mind?" rows="4"></textarea>
-        </div>
-
-        <input type="hidden" name="_next" value="{{ site.data.settings.contact_settings.confirmation_url }}" />
-        <input type="hidden" name="_subject" value="{{ site.data.settings.contact_settings.email_subject }}" />
-        <input type="text" name="_gotcha" style="display: none;" class="contact-form__gotcha" val="">
-
-        <div class="input-submit">
-          <input type="submit" class="button--fill" value="{{ site.data.settings.contact_settings.send_button_text }}">
-        </div>
-      </form>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This PR adds the code snippet from calendly so that users can schedule a zoom or phone call through the calendly service.
The embed replaces the contact form.

<img width="896" alt="Screen Shot 2020-10-06 at 3 47 57 PM" src="https://user-images.githubusercontent.com/349454/95253052-d78d4200-07eb-11eb-8188-2769c3e8f10a.png">
